### PR TITLE
Fix Debounce Issues

### DIFF
--- a/frontend/src/lib/components/feed.svelte
+++ b/frontend/src/lib/components/feed.svelte
@@ -6,6 +6,7 @@
     getLocationSearchValue,
   } from "$lib/states/searchBarState.svelte.js";
   import { fly } from "svelte/transition";
+  import { onMount } from "svelte";
 
   import { api } from "$lib/utils/api.svelte.js";
 
@@ -43,8 +44,8 @@
     }
   };
 
-  $effect(() => {
-    feed = getFeed();
+  onMount(() => {
+    feed = [...getFeed()];
     getIsLoggedIn();
   });
 </script>


### PR DESCRIPTION
fixes #2 

Currently, whenever the feed is open, the effect is basically changing the order of the feed with every state update. This makes it so that whenever you move the map and click on an entry, the focus on that entry is gone and the feed moves around. The solution to this appears to be pretty easy:

Replace the effect with an `onMount` (which should've been the case from the start), and then using a shallow copy for the feed.